### PR TITLE
Try to fix fastg problem

### DIFF
--- a/readscanAssembler/ContigGraph.cpp
+++ b/readscanAssembler/ContigGraph.cpp
@@ -1174,8 +1174,8 @@ void ContigGraph::printGraph(string fileName){
     printf("printed %d node-connected contigs\n", node_contig_count);
     //prints isolated contigs
     for(auto it = isolated_contigs.begin(); it != isolated_contigs.end(); it++){
-        Contig contig = *it;
-        printContigFastG(&fastgFile, &contig);
+        Contig* contig = &*it;
+        printContigFastG(&fastgFile, contig);
 
     }
     printf("printed %d isolated contigs\n", isolated_contigs.size());


### PR DESCRIPTION
This should do the trick, but I'm not sure what you were running on or where you were seeing the problem, so I'll let you make sure it works now before merging this.  

The problem was that it was copying the contig into a new variable before printing, and right now the way I get a unique ID from a contig is by getting the address its stored at. This is really a really brittle solution, as we're seeing here, but should work fine as long as we don't move the Contig value into a new container.
